### PR TITLE
Update include_header.php

### DIFF
--- a/src/themes/include_header.php
+++ b/src/themes/include_header.php
@@ -30,7 +30,7 @@ if(
 }
 
 
-$menuXML = new SimpleXMLElement(BASE_DIRECTORY."themes/".$THEME."/themeinfo.xml", NULL, true);
+$menuXML = new SimpleXMLElement(BASE_DIRECTORY."themes/".$THEME."/themeinfo.xml", 0, true);
 
 // Check if user is logged in
 if(isset($_SESSION['btUsername']) && isset($_SESSION['btPassword'])) {


### PR DESCRIPTION
fixing depreciation warning: 
 Deprecated: SimpleXMLElement::__construct(): Passing null to parameter #2 ($options) of type int is deprecated in /home/retrodig/public_html/zarksfallenangels/themes/include_header.php on line 33

Which gets shown at top of page.