### PR TITLE
console: don't allow user to load a -separator-

### DIFF
--- a/src/members/console.php
+++ b/src/members/console.php
@@ -56,9 +56,8 @@ $EXTERNAL_JAVASCRIPT .= "
 
 // Check if the page is called directly with 'cID' in the query string and the page title is '-separator-'
 if (isset($_GET['cID']) && $consoleInfo['pagetitle'] === '-separator-') {
-    // Redirect to console.php
-    header('Location: console.php');
-    exit;
+	header('Location: console.php');
+	exit;
 }
 
 $arrTinyMCEPages = ["Manage News", "Post News", "Add Custom Page", "Manage Custom Pages", "Add Custom Form Page", "Manage Custom Form Pages", "Post Topic", "Manage Forum Posts", "Add Menu Item", "Add Menu Category", "Manage Menu Categories", "Manage Menu Items", "Edit Profile"];

--- a/src/members/console.php
+++ b/src/members/console.php
@@ -54,6 +54,12 @@ $EXTERNAL_JAVASCRIPT .= "
 <link rel='stylesheet' media='screen' type='text/css' href='".$MAIN_ROOT."js/colorpicker/jquery.miniColors.css'>
 ";
 
+// Check if the page is called directly with 'cID' in the query string and the page title is '-separator-'
+if (isset($_GET['cID']) && $consoleInfo['pagetitle'] === '-separator-') {
+    // Redirect to console.php
+    header('Location: console.php');
+    exit;
+}
 
 $arrTinyMCEPages = ["Manage News", "Post News", "Add Custom Page", "Manage Custom Pages", "Add Custom Form Page", "Manage Custom Form Pages", "Post Topic", "Manage Forum Posts", "Add Menu Item", "Add Menu Category", "Manage Menu Categories", "Manage Menu Items", "Edit Profile"];
 $arrAceEditorPages = ["Modify Current Theme", "Add Menu Category", "Add Menu Item", "Manage Menu Categories", "Manage Menu Items"];

--- a/src/members/console.php
+++ b/src/members/console.php
@@ -54,7 +54,7 @@ $EXTERNAL_JAVASCRIPT .= "
 <link rel='stylesheet' media='screen' type='text/css' href='".$MAIN_ROOT."js/colorpicker/jquery.miniColors.css'>
 ";
 
-// Check if the page is called directly with 'cID' in the query string and the page title is '-separator-'
+// Don't let user load a -separator- page
 if (isset($_GET['cID']) && $consoleInfo['pagetitle'] === '-separator-') {
 	header('Location: console.php');
 	exit;


### PR DESCRIPTION
Should fix the seperator page giving error instead of redirecting to console.php..

Fix #139